### PR TITLE
Fix Authority bug in Get-MSALToken cmdlet in v4.37

### DIFF
--- a/src/Get-MsalToken.ps1
+++ b/src/Get-MsalToken.ps1
@@ -335,7 +335,7 @@ function Get-MsalToken {
             "*" {
                 if ($AzureCloudInstance -and $TenantId) { [void] $AquireTokenParameters.WithAuthority($AzureCloudInstance, $TenantId) }
                 elseif ($AzureCloudInstance) { [void] $AquireTokenParameters.WithAuthority($AzureCloudInstance, 'common') }
-                elseif ($TenantId) { [void] $AquireTokenParameters.WithAuthority(('https://{0}' -f $ClientApplication.AppConfig.Authority.AuthorityInfo.Host), $TenantId) }
+                elseif ($TenantId) { [void] $AquireTokenParameters.WithAuthority(('https://{0}' -f $ClientApplication.AppConfig.AuthorityInfo.Host), $TenantId) }
                 if ($Authority) { [void] $AquireTokenParameters.WithAuthority($Authority.AbsoluteUri) }
                 if ($CorrelationId) { [void] $AquireTokenParameters.WithCorrelationId($CorrelationId) }
                 if ($ExtraQueryParameters) { [void] $AquireTokenParameters.WithExtraQueryParameters((ConvertTo-Dictionary $ExtraQueryParameters -KeyType ([string]) -ValueType ([string]))) }


### PR DESCRIPTION
In v 4.37.0.0, a bug was introduced causing the error described in Issue 45: https://github.com/AzureAD/MSAL.PS/issues/45
Microsoft.Identity.Client.ConfidentialClientApplication.ApplicationConfiguration does not have an "Authority" member. The previous code referencing AuthorityInfo is correct.