### PR TITLE
Object check for $ClientApplication.AppConfig substructure options

### DIFF
--- a/src/Get-MsalToken.ps1
+++ b/src/Get-MsalToken.ps1
@@ -336,12 +336,10 @@ function Get-MsalToken {
                 if ($AzureCloudInstance -and $TenantId) { [void] $AquireTokenParameters.WithAuthority($AzureCloudInstance, $TenantId) }
                 elseif ($AzureCloudInstance) { [void] $AquireTokenParameters.WithAuthority($AzureCloudInstance, 'common') }
                 elseif ($TenantId) {
-                    if( Get-Member -InputObject $ClientApplication.AppConfig -Name "AuthorityInfo" -MemberType Properties )
-                    {
+                    if (Get-Member -InputObject $ClientApplication.AppConfig -Name "AuthorityInfo" -MemberType Properties) {
                         [void] $AquireTokenParameters.WithAuthority(('https://{0}' -f $ClientApplication.AppConfig.AuthorityInfo.Host), $TenantId)
                     }
-                    else
-                    {
+                    else {
                         [void] $AquireTokenParameters.WithAuthority(('https://{0}' -f $ClientApplication.AppConfig.Authority.AuthorityInfo.Host), $TenantId)
                     }
                 }

--- a/src/Get-MsalToken.ps1
+++ b/src/Get-MsalToken.ps1
@@ -335,7 +335,16 @@ function Get-MsalToken {
             "*" {
                 if ($AzureCloudInstance -and $TenantId) { [void] $AquireTokenParameters.WithAuthority($AzureCloudInstance, $TenantId) }
                 elseif ($AzureCloudInstance) { [void] $AquireTokenParameters.WithAuthority($AzureCloudInstance, 'common') }
-                elseif ($TenantId) { [void] $AquireTokenParameters.WithAuthority(('https://{0}' -f $ClientApplication.AppConfig.Authority.AuthorityInfo.Host), $TenantId) }
+                elseif ($TenantId) {
+                    if( Get-Member -InputObject $ClientApplication.AppConfig -Name "AuthorityInfo" -MemberType Properties )
+                    {
+                        [void] $AquireTokenParameters.WithAuthority(('https://{0}' -f $ClientApplication.AppConfig.AuthorityInfo.Host), $TenantId)
+                    }
+                    else
+                    {
+                        [void] $AquireTokenParameters.WithAuthority(('https://{0}' -f $ClientApplication.AppConfig.Authority.AuthorityInfo.Host), $TenantId)
+                    }
+                }
                 if ($Authority) { [void] $AquireTokenParameters.WithAuthority($Authority.AbsoluteUri) }
                 if ($CorrelationId) { [void] $AquireTokenParameters.WithCorrelationId($CorrelationId) }
                 if ($ExtraQueryParameters) { [void] $AquireTokenParameters.WithExtraQueryParameters((ConvertTo-Dictionary $ExtraQueryParameters -KeyType ([string]) -ValueType ([string]))) }


### PR DESCRIPTION
Possible fix for #45

Added check on $ClientApplication.AppConfig to handle substructure change for AuthorityInfo.Host or the old Authority.AuthorityInfo.Host.

