### PR TITLE
Jezour1sw/enable-define own path to store cached tokens

### DIFF
--- a/src/Enable-MsalTokenCacheOnDisk.ps1
+++ b/src/Enable-MsalTokenCacheOnDisk.ps1
@@ -7,6 +7,9 @@
     PS C:\>Enable-MsalTokenCacheOnDisk $ClientApplication
     Enable client application to use persistent token cache on disk.
 .EXAMPLE
+    PS C:\>Enable-MsalTokenCacheOnDisk $ClientApplication -CacheFilePath $CacheFilePath
+    Enable client application to use persistent token cache on disk.
+.EXAMPLE
     PS C:\>Enable-MsalTokenCacheOnDisk $ClientApplication -PassThru
     Enable client application to use persistent token cache on disk and return the object.
 #>
@@ -21,6 +24,9 @@ function Enable-MsalTokenCacheOnDisk {
         # Confidential client application
         [Parameter(Mandatory = $true, ParameterSetName = 'ConfidentialClient', Position = 0, ValueFromPipeline = $true)]
         [Microsoft.Identity.Client.IConfidentialClientApplication] $ConfidentialClientApplication,
+        # Path to Cache File
+        [Parameter(Mandatory = $false)]
+        [string] $CacheFilePath,
         # Returns client application
         [Parameter(Mandatory = $false)]
         [switch] $PassThru
@@ -39,9 +45,9 @@ function Enable-MsalTokenCacheOnDisk {
 
     if ([System.Environment]::OSVersion.Platform -eq 'Win32NT' -and $PSVersionTable.PSVersion -lt [version]'6.0') {
         if ($ClientApplication -is [Microsoft.Identity.Client.IConfidentialClientApplication]) {
-            [TokenCacheHelper]::EnableSerialization($ClientApplication.AppTokenCache)
+            [TokenCacheHelper]::EnableSerialization($ClientApplication.AppTokenCache, $CacheFilePath)
         }
-        [TokenCacheHelper]::EnableSerialization($ClientApplication.UserTokenCache)
+        [TokenCacheHelper]::EnableSerialization($ClientApplication.UserTokenCache, $CacheFilePath)
     }
     else {
         Write-Warning 'Using TokenCache On Disk only works on Windows platform using Windows PowerShell. The token cache will stored in memory and not persisted on disk.'

--- a/src/internal/TokenCacheHelper.cs
+++ b/src/internal/TokenCacheHelper.cs
@@ -5,16 +5,19 @@ using Microsoft.Identity.Client;
 
 public static class TokenCacheHelper
 {
-    public static void EnableSerialization(ITokenCache tokenCache)
+    public static void EnableSerialization(ITokenCache tokenCache, string username = "")
     {
         tokenCache.SetBeforeAccess(BeforeAccessNotification);
         tokenCache.SetAfterAccess(AfterAccessNotification);
+        Username = username;
     }
 
     /// <summary>
     /// Path to the token cache
     /// </summary>
-    public static readonly string CacheFilePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "MSAL.PS", "MSAL.PS.msalcache.bin3");
+    private static readonly string Username = "";
+    
+    public static readonly string CacheFilePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "MSAL.PS", Username + "MSAL.PS.msalcache.bin3");
 
     private static readonly object FileLock = new object();
 

--- a/src/internal/TokenCacheHelper.cs
+++ b/src/internal/TokenCacheHelper.cs
@@ -5,19 +5,21 @@ using Microsoft.Identity.Client;
 
 public static class TokenCacheHelper
 {
-    public static void EnableSerialization(ITokenCache tokenCache, string username = "")
+    public static void EnableSerialization(ITokenCache tokenCache, string cacheFilePath = "")
     {
         tokenCache.SetBeforeAccess(BeforeAccessNotification);
         tokenCache.SetAfterAccess(AfterAccessNotification);
-        Username = username;
+        if(string.IsNullOrEmpty(CacheFilePath))
+            CacheFilePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "MSAL.PS", "MSAL.PS.msalcache.bin3");
+        else
+            CacheFilePath = cacheFilePath;
     }
 
     /// <summary>
     /// Path to the token cache
     /// </summary>
-    private static readonly string Username = "";
     
-    public static readonly string CacheFilePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "MSAL.PS", Username + "MSAL.PS.msalcache.bin3");
+    public static readonly string CacheFilePath;
 
     private static readonly object FileLock = new object();
 


### PR DESCRIPTION
I'm facing a situation where is required to use more AAD users (via username/password) to get a token.
My intention is to be able to store for each such AAD user the token in a separate file.